### PR TITLE
Better version detection on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tgmodules/version_manager.js
+++ b/tgmodules/version_manager.js
@@ -58,15 +58,14 @@ function getLocalFrameworkVersion(licenseContents) {
 
     return new Promise((resolve, reject) => {
 
-            var pos = licenseContents.search("Version:")
-            var start = pos + 9 //allow for the word Version: 
-            var end = start+30
-            var localFrameworkVersion = licenseContents.substring(start, end)
+            var localFrameworkVersionMatch = licenseContents.match(/(?<=Version:\s)\d+(\.\d+)*/)
+            
+            if (!localFrameworkVersionMatch) {
+                reject(new Error('Unable to find "Version: " in license.txt'));
+            }
 
-    var newLine = `
-`;
-            var firstAsteriskPos = localFrameworkVersion.search(newLine)
-            localFrameworkVersion = localFrameworkVersion.substring(0, firstAsteriskPos)
+            var localFrameworkVersion = localFrameworkVersionMatch[0];
+
             resolve(localFrameworkVersion)
 
 


### PR DESCRIPTION
I was unable to properly load a project that was cloned to a repository on windows in CRLF rather than Unix LF line endings.
By using a regex i'm able to more reliably capture the version string.

In addition, i added `node_modules` to .gitignore to reduce the files being watched by editors, e.g. VSCode.